### PR TITLE
Update README: dependencies of PHYEX require Python >=3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Several presentations were done, the materials can be found on the [wiki](https:
 Prerequisites:
   - an internet connexion (with access to the github servers) is needed only for the installation
     and, for offline tests (testprogs), when the fiat version to use change
-  - python > 3.8 (but only tested with version 3.10)
+  - python >= 3.10 (but only tested with version 3.10)
   - some python packages (available on PyPI). All these modules can be installed by ```pip install -r requirements.txt```:
     - pyfortool to transform the source code
     - numpy and pandas for the testprogs


### PR DESCRIPTION
The recent update of `ial_build` to `1.3.0` requires Python >= 3.10 (https://github.com/ACCORD-NWP/IAL-build/blob/e4abd351bf177dbf3426590c560ae8bb214e297b/pyproject.toml#L6). I updated the README. I did also some test just to be sure:

## Installing PHYEX Python dependices

|Version|Works?|
|-------|--------|
|Python 3.8.2|Error 1|
|Python 3.8.5|Error 1|
|Python 3.8.8|Error 1|
|Python 3.8.10|Error 1|
|Python 3.9.7|Error 2|
|Python 3.9.12|Error 2|
|Python 3.10.4|Works|
|Python 3.10.10|Works|
|Python 3.11.5|Works|
|Python 3.11.7|Works|
|Python 3.12.4|Works|
|Python 3.12.7|Works|
|Python 3.12.9|Works|

It works well on Python 3.10/3.11/3.12 :) With the new Python/pip the error 2 is more detailed.

### Error 1

```shell
ERROR: Could not find a version that satisfies the requirement ial_build==1.3.0 (from versions: none)
ERROR: No matching distribution found for ial_build==1.3.0
```

### Error 2

```shell
ERROR: Ignored the following versions that require a different python version: 1.3.0 Requires-Python >=3.10; 1.3.2 Requires-Python >=3.10; 1.3.3 Requires-Python >=3.10; 2.0.1 Requires-Python >=3.10; 2.0.2 Requires-Python >=3.10; 2.0.3 Requires-Python >=3.10; 2.0.4 Requires-Python >=3.10; 2.1.0 Requires-Python >=3.10; 2.1.0rc1 Requires-Python >=3.10; 2.1.1 Requires-Python >=3.10; 2.1.2 Requires-Python >=3.10; 2.1.3 Requires-Python >=3.10; 2.2.0 Requires-Python >=3.10; 2.2.0rc1 Requires-Python >=3.10; 2.2.1 Requires-Python >=3.10; 2.2.2 Requires-Python >=3.10; 2.2.3 Requires-Python >=3.10; 2.2.4 Requires-Python >=3.10; 2.2.5 Requires-Python >=3.10; 2.2.6 Requires-Python >=3.10; 2024.10.0 Requires-Python >=3.10; 2024.11.0 Requires-Python >=3.10; 2024.9.0 Requires-Python >=3.10; 2025.1.0 Requires-Python >=3.10; 2025.1.1 Requires-Python >=3.10; 2025.1.2 Requires-Python >=3.10; 2025.3.0 Requires-Python >=3.10; 2025.3.1 Requires-Python >=3.10; 2025.4.0 Requires-Python >=3.10; 3.10.0 Requires-Python >=3.10; 3.10.0rc1 Requires-Python >=3.10; 3.10.1 Requires-Python >=3.10; 3.10.3 Requires-Python >=3.10
ERROR: Could not find a version that satisfies the requirement ial_build==1.3.0 (from versions: none)
ERROR: No matching distribution found for ial_build==1.3.0
```