### PR TITLE
Use of LEXCLDROP in rain_ice_old.F90

### DIFF
--- a/micro/rain_ice_old.F90
+++ b/micro/rain_ice_old.F90
@@ -461,7 +461,7 @@ IF (NINT(ICEP%XFRMIN(18)) == 1) LTIW=.TRUE.
 
 IF (OSEDIC) THEN
   ZRAY(:,:)   = 0.
-  IF (ICEP%XFRMIN(26)>0.001 .OR. OAERONRT) THEN
+  IF (ICEP%XFRMIN(26)>0.001 .OR. (OAERONRT.AND.PARAMI%LEXCLDROP)) THEN
     ! Assume "average" distr. func for simplicity
     DO JK = D%NKTB,D%NKTE
       DO JIJ = D%NIJB,D%NIJE
@@ -505,8 +505,8 @@ IF (OSEDIC.OR.OCND2.OR.LKOGAN) THEN
       ZZZZ(JIJ,JK) = ZZZT(JIJ,JK) - 0.5*PDZZ(JIJ,JK)
     ENDDO
   ENDDO
-  IF (OAERONRT) THEN
-  !Consider Cloud droplets obtained from CAMS aerosol mixing ratio fields
+  IF (PARAMI%LEXCLDROP) THEN
+  !Consider external cloud droplet number concentration.
     DO JK = D%NKTB, D%NKTE
       DO JIJ = D%NIJB, D%NIJE
         ZCONC3D(JIJ,JK) = PCLDROP(JIJ,JK)


### PR DESCRIPTION
Hi @AlexandreMary and @SebastienRietteMTO,

Comming back to the simplification of rain_ice_old. I realised that LEXCLDROP was not used when I made the changes. I have introduced it modifying two conditionals statements.