### PR TITLE
Add OpenACC support

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -28,6 +28,10 @@ ecbuild_add_option(FEATURE OMP
                    DESCRIPTION "Support for OpenMP shared memory parallelism"
                    REQUIRED_PACKAGES "OpenMP COMPONENTS Fortran")
 
+ecbuild_add_option(FEATURE ACC
+                   DESCRIPTION "Support for OpenACC"
+                   REQUIRED_PACKAGES "OpenACC COMPONENTS Fortran")
+
 if(HAVE_DOUBLE_PRECISION)
   list(APPEND precision_list dp) 
 endif()
@@ -123,6 +127,10 @@ foreach(PRECISION ${precision_list})
     target_link_libraries(phyex_${PRECISION} PRIVATE OpenMP::OpenMP_Fortran )
   endif()
 
+  if(HAVE_ACC)
+    target_link_libraries(phyex_${PRECISION} PRIVATE OpenACC::OpenACC_Fortran )
+  endif()
+
   # Compilation option to use for unqualified REALs
   target_compile_options(phyex_${PRECISION} PUBLIC
     $<$<COMPILE_LANGUAGE:Fortran>:${PHYEX_COMPILE_OPTIONS_REAL}>)
@@ -167,6 +175,10 @@ foreach(PRECISION ${precision_list})
 
       if(HAVE_OMP)
         target_link_libraries(${NAME} PRIVATE OpenMP::OpenMP_Fortran )
+      endif()
+
+      if(HAVE_ACC)
+        target_link_libraries(${NAME} PRIVATE OpenACC::OpenACC_Fortran )
       endif()
 
       if(DEFINED FPP_FLAGS_TESTPROGS)


### PR DESCRIPTION
Add the ENABLE_ACC option to the CMakeLists.txt; this allows for compiling PHYEX with OpenACC options.