### PR TITLE
Adds safety for single precision runs in mode_ice4_slow

### DIFF
--- a/micro/mode_ice4_slow.F90
+++ b/micro/mode_ice4_slow.F90
@@ -79,7 +79,7 @@ REAL, DIMENSION(KPROMA),      INTENT(INOUT) :: PRVDEPG  ! Deposition on r_g
 !
 REAL, DIMENSION(KPROMA) :: ZCRIAUTI
 INTEGER                 :: JL
-REAL            :: ZREDGR,ZREDSN
+REAL            :: ZREDGR,ZREDSN,MAX_EXP_ARG
 REAL(KIND=JPHOOK) :: ZHOOK_HANDLE
 !-------------------------------------------------------------------------------
 !
@@ -92,6 +92,7 @@ IF (LHOOK) CALL DR_HOOK('ICE4_SLOW', 0, ZHOOK_HANDLE)
 ZREDGR  = 1.      ! Tuning of the deposition of graupel, 1. is ref. value 
 ZREDSN  = 1.      ! Tuning of the deposition of snow, 1. is ref. value
 
+MAX_EXP_ARG = 100.0
 IF(PARAMI%LOCND2) THEN
   IF(.NOT. PARAMI%LMODICEDEP) THEN
     ZREDGR  = ICEP%XFRMIN(39)  ! Tuning factor, may be /= 1. 
@@ -110,7 +111,7 @@ DO JL=1, KSIZE
   IF(PT(JL)<CST%XTT-35.0 .AND. PRCT(JL)>ICED%XRTMIN(2) .AND. LDCOMPUTE(JL)) THEN
     IF(.NOT. LDSOFT) THEN
       PRCHONI(JL) = MIN(1000.,ICEP%XHON*PRHODREF(JL)*PRCT(JL)       &
-                                 *EXP( ICEP%XALPHA3*(PT(JL)-CST%XTT)-ICEP%XBETA3 ))
+                                  *EXP( MIN(MAX_EXP_ARG,ICEP%XALPHA3*(PT(JL)-CST%XTT)-ICEP%XBETA3) ))
     ENDIF
   ELSE
     PRCHONI(JL) = 0.


### PR DESCRIPTION
Another problem when running sp with harmonie-arome.

In single precision, the argument of EXP can get too large. This is solved by MIN(MAX_EXP_ARG,...), where MAX_EXP_ARG = 100.0 is a completely arbitrary number. It was intended to be a quick fix, not as a permanent solution. Someone from the PHYEX developers can probably give better advice.

Some discussions regarding the choise of MAX_EXP_ARG can be found here: https://github.com/UMR-CNRM/PHYEX/pull/147#issuecomment-5105328556

Davai validation: https://www.umr-cnrm.fr/davai/lightView/3174

Note: the PR is based on this commit: c3e76b3dea87a063f18eed3d731c2caf49be7ede