### PR TITLE
Do not propagate -r8 option to IAL

### DIFF
--- a/src/common/CMakeLists.txt
+++ b/src/common/CMakeLists.txt
@@ -132,7 +132,7 @@ foreach(PRECISION ${precision_list})
   endif()
 
   # Compilation option to use for unqualified REALs
-  target_compile_options(phyex_${PRECISION} PUBLIC
+  target_compile_options(phyex_${PRECISION} PRIVATE
     $<$<COMPILE_LANGUAGE:Fortran>:${PHYEX_COMPILE_OPTIONS_REAL}>)
 
   if(HAVE_IFS_FLAGS)
@@ -186,7 +186,7 @@ foreach(PRECISION ${precision_list})
       endif()
 
       # Compilation option to use for unqualified REALs
-      target_compile_options(${NAME}_${PRECISION} PUBLIC
+      target_compile_options(${NAME}_${PRECISION} PRIVATE
         $<$<COMPILE_LANGUAGE:Fortran>:${PHYEX_COMPILE_OPTIONS_REAL}>)
     endforeach()
   endif()


### PR DESCRIPTION
Currently, the -r8 option (promotion of reals to doubles) is propagated from PHYEX to packages using PHYEX. The purpose of this PR is to avoid this issue; PUBLIC becomes PRIVATE before the -r8 option when creating a new library.